### PR TITLE
Fixes to linter errors

### DIFF
--- a/onvm/onvm_mgr/onvm_init.c
+++ b/onvm/onvm_mgr/onvm_init.c
@@ -103,17 +103,14 @@ check_all_ports_link_status(uint8_t port_num, uint32_t port_mask);
 #define TX_WTHRESH 0  /* Default values of TX write-back threshold reg. */
 
 static const struct rte_eth_conf port_conf = {
-    .rxmode =
-        {
+    .rxmode = {
             .mq_mode = ETH_MQ_RX_RSS,
             .max_rx_pkt_len = ETHER_MAX_LEN,
             .split_hdr_size = 0,
             .offloads = DEV_RX_OFFLOAD_CHECKSUM,
         },
-    .rx_adv_conf =
-        {
-            .rss_conf =
-                {
+    .rx_adv_conf = {
+            .rss_conf = {
                     .rss_key = rss_symmetric_key, .rss_hf = ETH_RSS_IP | ETH_RSS_UDP | ETH_RSS_TCP | ETH_RSS_L2_PAYLOAD,
                 },
         },

--- a/onvm/onvm_nflib/onvm_common.h
+++ b/onvm/onvm_nflib/onvm_common.h
@@ -39,8 +39,8 @@
  * onvm_common.h - shared data between host and NFs
  ********************************************************************/
 
-#ifndef _COMMON_H_
-#define _COMMON_H_
+#ifndef _ONVM_COMMON_H_
+#define _ONVM_COMMON_H_
 
 #include <stdint.h>
 
@@ -363,4 +363,4 @@ onvm_nf_is_valid(struct onvm_nf *nf) {
 
 #define RTE_LOGTYPE_APP RTE_LOGTYPE_USER1
 
-#endif  // _COMMON_H_
+#endif  // _ONVM_COMMON_H_

--- a/onvm/onvm_nflib/onvm_config_common.h
+++ b/onvm/onvm_nflib/onvm_config_common.h
@@ -205,4 +205,4 @@ onvm_config_create_onvm_args(cJSON* onvm_config, int* onvm_argc, char** onvm_arg
 int
 onvm_config_create_dpdk_args(cJSON* dpdk_config, int* dpdk_argc, char** dpdk_argv[]);
 
-#endif
+#endif  // _ONVM_CONFIG_COMMON_H_

--- a/onvm/onvm_nflib/onvm_nflib.c
+++ b/onvm/onvm_nflib/onvm_nflib.c
@@ -520,7 +520,7 @@ onvm_nflib_thread_main_loop(void *arg) {
                         keep_running = !(*callback)(nf->info) && keep_running;
                 }
 
-                if (info->time_to_live && unlikely((rte_get_tsc_cycles() - start_time) * 
+                if (info->time_to_live && unlikely((rte_get_tsc_cycles() - start_time) *
                                           TIME_TTL_MULTIPLIER / rte_get_timer_hz() >= info->time_to_live)) {
                         printf("Time to live exceeded, shutting down\n");
                         keep_running = 0;

--- a/onvm/onvm_nflib/onvm_sc_mgr.h
+++ b/onvm/onvm_nflib/onvm_sc_mgr.h
@@ -38,8 +38,8 @@
  * onvm_sc_mgr.h - service chain functions for manager
  ********************************************************************/
 
-#ifndef _SC_MGR_H_
-#define _SC_MGR_H_
+#ifndef _ONVM_SC_MGR_H_
+#define _ONVM_SC_MGR_H_
 
 #include <rte_mbuf.h>
 #include "onvm_common.h"
@@ -76,4 +76,4 @@ onvm_sc_get(void);
 /*create service chain*/
 struct onvm_service_chain*
 onvm_sc_create(void);
-#endif  // _SC_MGR_H_
+#endif  // _ONVM_SC_MGR_H_


### PR DESCRIPTION
I tested with the linter style/gwclint.py with the arguments from `ci/helper_functions.sh` (`run_linter`). The only errors I got when using the linter were from flow_table/openflow.h, because of multi-line comments. I tried but couldn't figure out how to appease these errors.  
